### PR TITLE
Shield: Fix SSRF via redirects and enforce DoS limits

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -5,3 +5,8 @@
 1. Enforce hard limits on all list inputs (e.g., `MAX_NEWSLETTERS`).
 2. Always use `requests.get(stream=True)` for user-provided URLs.
 3. Read the response stream in chunks and count bytes, aborting if the size exceeds a safety threshold (e.g., 2MB).
+
+## 2026-02-04 - [SSRF Mitigation in Redirects]
+**Vulnerability:** Standard `requests.get` and `feedparser.parse` follow redirects automatically, allowing a malicious user to bypass initial URL checks (`is_safe_url`) by redirecting to a private IP (SSRF).
+**Learning:** Checking a URL once is not enough if the library follows redirects. Every hop must be validated.
+**Prevention:** Use a wrapper like `safe_requests_get` that disables auto-redirects (`allow_redirects=False`) and manually validates the `Location` header of each redirect against the security policy.

--- a/handler.py
+++ b/handler.py
@@ -11,6 +11,7 @@ from bs4 import BeautifulSoup
 import socket
 import ipaddress
 from urllib.parse import urlparse
+from security_utils import is_safe_url, safe_requests_get
 
 # Configuration
 ANTHROPIC_API_KEY = os.environ.get('ANTHROPIC_API_KEY')
@@ -59,7 +60,21 @@ def extract_substack_content(newsletter_url: str, max_posts: int = 5) -> List[Di
             print(f"Skipping unsafe RSS URL: {rss_url}")
             return posts
 
-        feed = feedparser.parse(rss_url)
+        # Fetch RSS feed securely
+        with safe_requests_get(rss_url, timeout=10, stream=True) as response:
+            if response.status_code != 200:
+                print(f"Failed to fetch RSS feed: {rss_url}")
+                return posts
+
+            # Limit RSS feed size
+            content_bytes = b""
+            for chunk in response.iter_content(chunk_size=8192):
+                content_bytes += chunk
+                if len(content_bytes) > MAX_RESPONSE_SIZE_BYTES:
+                    print(f"RSS feed too large: {rss_url}")
+                    return posts
+
+            feed = feedparser.parse(content_bytes)
         
         for entry in feed.entries[:max_posts]:
             # Get full content by scraping the actual post
@@ -99,8 +114,8 @@ def scrape_post_content(post_url: str) -> str:
             'User-Agent': 'Mozilla/5.0 (compatible; AI Research Bot/1.0)'
         }
         
-        # Use stream=True to prevent loading massive files into memory
-        with requests.get(post_url, headers=headers, timeout=10, stream=True) as response:
+        # Use safe_requests_get with stream=True
+        with safe_requests_get(post_url, headers=headers, timeout=10, stream=True) as response:
             if response.status_code != 200:
                 return ""
 
@@ -293,17 +308,7 @@ def handler(event):
     
     # Configuration from input
     newsletters = job_input.get('newsletters', list(RESEARCH_TARGETS.values()))
-    # Enforce limit on number of newsletters
-    if len(newsletters) > MAX_NEWSLETTERS:
-        print(f"⚠️ Truncating newsletters list from {len(newsletters)} to {MAX_NEWSLETTERS}")
-        newsletters = newsletters[:MAX_NEWSLETTERS]
-
     posts_per_newsletter = job_input.get('posts_per_newsletter', 3)
-    # Enforce limit on posts per newsletter
-    if posts_per_newsletter > MAX_POSTS_PER_NEWSLETTER:
-        print(f"⚠️ Capping posts_per_newsletter from {posts_per_newsletter} to {MAX_POSTS_PER_NEWSLETTER}")
-        posts_per_newsletter = MAX_POSTS_PER_NEWSLETTER
-
     include_outreach_strategy = job_input.get('include_outreach_strategy', True)
 
     # Security validation

--- a/tests/test_dos_limits.py
+++ b/tests/test_dos_limits.py
@@ -18,10 +18,12 @@ class TestHandlerDoS(unittest.TestCase):
             }
         }
 
-        handler(event)
+        result = handler(event)
 
-        # Verify that extract_substack_content was called with the CAPPED number
-        mock_extract.assert_called_with('https://example.com', MAX_POSTS_PER_NEWSLETTER)
+        # Verify that an error is returned (no silent truncation)
+        self.assertIn('error', result)
+        self.assertIn(f"Max allowed: {MAX_POSTS_PER_NEWSLETTER}", result['error'])
+        mock_extract.assert_not_called()
 
     @patch('handler.extract_substack_content')
     @patch('handler.analyze_research_intelligence')
@@ -38,10 +40,12 @@ class TestHandlerDoS(unittest.TestCase):
             }
         }
 
-        handler(event)
+        result = handler(event)
 
-        # Verify it processed only MAX_NEWSLETTERS
-        self.assertEqual(mock_extract.call_count, MAX_NEWSLETTERS)
+        # Verify that an error is returned (no silent truncation)
+        self.assertIn('error', result)
+        self.assertIn(f"Max allowed: {MAX_NEWSLETTERS}", result['error'])
+        mock_extract.assert_not_called()
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_safe_requests.py
+++ b/tests/test_safe_requests.py
@@ -1,0 +1,88 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import requests
+from security_utils import safe_requests_get
+
+class TestSafeRequestsGet(unittest.TestCase):
+    @patch('requests.get')
+    @patch('security_utils.is_safe_url')
+    def test_safe_url_success(self, mock_is_safe_url, mock_get):
+        mock_is_safe_url.return_value = True
+        mock_resp = MagicMock()
+        mock_resp.is_redirect = False
+        mock_resp.status_code = 200
+        mock_get.return_value = mock_resp
+
+        resp = safe_requests_get("http://example.com")
+        self.assertEqual(resp.status_code, 200)
+        mock_is_safe_url.assert_called_with("http://example.com")
+
+    @patch('requests.get')
+    @patch('security_utils.is_safe_url')
+    def test_unsafe_url_initial(self, mock_is_safe_url, mock_get):
+        mock_is_safe_url.return_value = False
+
+        with self.assertRaisesRegex(ValueError, "Unsafe URL blocked"):
+            safe_requests_get("http://unsafe.com")
+
+    @patch('requests.get')
+    @patch('security_utils.is_safe_url')
+    def test_safe_redirect_to_safe(self, mock_is_safe_url, mock_get):
+        # Setup: http://start.com -> http://end.com
+        mock_is_safe_url.side_effect = [True, True] # Both safe
+
+        resp1 = MagicMock()
+        resp1.is_redirect = True
+        resp1.headers = {'Location': 'http://end.com'}
+
+        resp2 = MagicMock()
+        resp2.is_redirect = False
+        resp2.status_code = 200
+
+        mock_get.side_effect = [resp1, resp2]
+
+        resp = safe_requests_get("http://start.com")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(mock_get.call_count, 2)
+        resp1.close.assert_called_once() # Ensure intermediate response is closed
+
+    @patch('requests.get')
+    @patch('security_utils.is_safe_url')
+    def test_safe_redirect_to_unsafe(self, mock_is_safe_url, mock_get):
+        # Setup: http://start.com -> http://unsafe.com
+        def is_safe_side_effect(url):
+            if url == "http://start.com": return True
+            if url == "http://unsafe.com": return False
+            return True
+
+        mock_is_safe_url.side_effect = is_safe_side_effect
+
+        resp1 = MagicMock()
+        resp1.is_redirect = True
+        resp1.headers = {'Location': 'http://unsafe.com'}
+
+        mock_get.return_value = resp1
+
+        with self.assertRaisesRegex(ValueError, "Unsafe URL blocked"):
+            safe_requests_get("http://start.com")
+
+        resp1.close.assert_called_once()
+
+    @patch('requests.get')
+    @patch('security_utils.is_safe_url')
+    def test_too_many_redirects(self, mock_is_safe_url, mock_get):
+        mock_is_safe_url.return_value = True
+
+        resp = MagicMock()
+        resp.is_redirect = True
+        resp.headers = {'Location': 'http://next.com'}
+
+        mock_get.return_value = resp
+
+        with self.assertRaisesRegex(ValueError, "Too many redirects"):
+            safe_requests_get("http://start.com", max_redirects=2)
+
+        self.assertEqual(mock_get.call_count, 3) # initial + 2 redirects
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability:
1. SSRF via redirects: `requests.get` and `feedparser.parse` followed redirects automatically, allowing bypass of `is_safe_url` checks.
2. DoS via Input Limits: Input limits were silently truncated instead of rejecting requests, and some network fetches lacked size limits.
3. Missing Imports: `handler.py` was missing imports for `is_safe_url`.

🎯 Impact:
1. Attackers could access internal services (metadata, localhost) by providing a URL that redirects to them.
2. Attackers could cause OOM or resource exhaustion by providing massive files or unlimited lists.

🔧 Fix:
1. Implemented `safe_requests_get` in `security_utils.py` that handles redirects manually and validates every hop.
2. Updated `handler.py` to use `safe_requests_get` for both RSS and Post content fetching.
3. Added size limits to RSS fetching.
4. Removed silent truncation in `handler.py` to allow validation logic to return explicit errors.
5. Added tests for `safe_requests_get` and updated DoS limit tests.

✅ Verification:
Run `export PYTHONPATH=$PYTHONPATH:. && python3 -m unittest discover tests` to verify all tests pass.

---
*PR created automatically by Jules for task [14725621476123006901](https://jules.google.com/task/14725621476123006901) started by @thebearwithabite*