### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF via redirect and inconsistent DoS limits

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -5,3 +5,8 @@
 1. Enforce hard limits on all list inputs (e.g., `MAX_NEWSLETTERS`).
 2. Always use `requests.get(stream=True)` for user-provided URLs.
 3. Read the response stream in chunks and count bytes, aborting if the size exceeds a safety threshold (e.g., 2MB).
+
+## 2026-02-05 - [SSRF via Redirects & DoS Policy]
+**Vulnerability:** The application was vulnerable to SSRF because `requests.get` follows redirects by default, bypassing the initial `is_safe_url` check. Also, DoS limits were implemented via silent truncation, contradicting the security policy of explicit error returns.
+**Learning:** `requests` (and `feedparser`) are dangerous when handling untrusted URLs even with an initial IP check. A custom "safe getter" that handles redirects manually is required. Also, code behavior should align with documented security policies (truncation vs error).
+**Prevention:** Use `safe_requests_get` for all external URL fetching. Ensure input limits trigger explicit errors as per policy.

--- a/handler.py
+++ b/handler.py
@@ -11,6 +11,7 @@ from bs4 import BeautifulSoup
 import socket
 import ipaddress
 from urllib.parse import urlparse
+from security_utils import is_safe_url, safe_requests_get
 
 # Configuration
 ANTHROPIC_API_KEY = os.environ.get('ANTHROPIC_API_KEY')
@@ -55,11 +56,12 @@ def extract_substack_content(newsletter_url: str, max_posts: int = 5) -> List[Di
         # Try RSS feed first (most reliable)
         rss_url = f"{newsletter_url}/feed"
 
-        if not is_safe_url(rss_url):
-            print(f"Skipping unsafe RSS URL: {rss_url}")
+        rss_response = safe_requests_get(rss_url, timeout=10)
+        if not rss_response or rss_response.status_code != 200:
+            print(f"Skipping unsafe or failed RSS URL: {rss_url}")
             return posts
 
-        feed = feedparser.parse(rss_url)
+        feed = feedparser.parse(rss_response.content)
         
         for entry in feed.entries[:max_posts]:
             # Get full content by scraping the actual post
@@ -100,7 +102,11 @@ def scrape_post_content(post_url: str) -> str:
         }
         
         # Use stream=True to prevent loading massive files into memory
-        with requests.get(post_url, headers=headers, timeout=10, stream=True) as response:
+        response = safe_requests_get(post_url, headers=headers, timeout=10, stream=True)
+        if not response:
+            return ""
+
+        with response:
             if response.status_code != 200:
                 return ""
 
@@ -294,15 +300,10 @@ def handler(event):
     # Configuration from input
     newsletters = job_input.get('newsletters', list(RESEARCH_TARGETS.values()))
     # Enforce limit on number of newsletters
-    if len(newsletters) > MAX_NEWSLETTERS:
-        print(f"⚠️ Truncating newsletters list from {len(newsletters)} to {MAX_NEWSLETTERS}")
-        newsletters = newsletters[:MAX_NEWSLETTERS]
+    # Limits are enforced via error return below
 
     posts_per_newsletter = job_input.get('posts_per_newsletter', 3)
-    # Enforce limit on posts per newsletter
-    if posts_per_newsletter > MAX_POSTS_PER_NEWSLETTER:
-        print(f"⚠️ Capping posts_per_newsletter from {posts_per_newsletter} to {MAX_POSTS_PER_NEWSLETTER}")
-        posts_per_newsletter = MAX_POSTS_PER_NEWSLETTER
+    # Limits are enforced via error return below
 
     include_outreach_strategy = job_input.get('include_outreach_strategy', True)
 

--- a/security_utils.py
+++ b/security_utils.py
@@ -1,6 +1,7 @@
 import ipaddress
 import socket
-from urllib.parse import urlparse
+import requests
+from urllib.parse import urlparse, urljoin
 
 def is_safe_url(url: str) -> bool:
     """
@@ -28,19 +29,13 @@ def is_safe_url(url: str) -> bool:
             return False
         return True
     except ValueError:
-        # Hostname is a domain, we need to be careful about DNS rebinding.
-        # Ideally, we would resolve here and use the IP for the request.
-        # Since we can't easily patch requests/feedparser to use a specific IP without
-        # complex changes, we will do a best-effort check here.
         pass
 
     if hostname.lower() in ('localhost',):
         return False
 
     # Optional: Resolve the domain to check if it points to a private IP.
-    # This protects against domains configured to point to 127.0.0.1 etc.
     try:
-        # valid domains can still resolve to private IPs
         addr_info = socket.getaddrinfo(hostname, None)
         for _, _, _, _, sockaddr in addr_info:
             ip = ipaddress.ip_address(sockaddr[0])
@@ -49,10 +44,55 @@ def is_safe_url(url: str) -> bool:
             if ip.is_multicast:
                 return False
     except socket.gaierror:
-        # If we can't resolve it, it's safer to reject, or accept and let the request fail.
-        # Blocking unresolved domains is safer for SSRF prevention.
         return False
     except Exception:
         return False
 
     return True
+
+def safe_requests_get(url, max_redirects=5, **kwargs):
+    """
+    Safely performs a GET request, validating the URL and all redirects against SSRF.
+    """
+    if not is_safe_url(url):
+        print(f"Blocked initial unsafe URL: {url}")
+        return None
+
+    # Force allow_redirects=False to handle them manually
+    kwargs['allow_redirects'] = False
+
+    current_url = url
+    history = []
+
+    try:
+        for _ in range(max_redirects + 1):
+            response = requests.get(current_url, **kwargs)
+
+            if response.is_redirect:
+                response.close() # Close connection for the redirect response
+                location = response.headers.get('Location')
+                if not location:
+                    return response
+
+                # Resolve relative redirects
+                next_url = urljoin(current_url, location)
+
+                if not is_safe_url(next_url):
+                    print(f"Blocked redirect to unsafe URL: {next_url}")
+                    return None
+
+                history.append(response)
+                current_url = next_url
+                continue
+            else:
+                # Final response
+                response.history = history
+                return response
+
+        # Too many redirects
+        print(f"Too many redirects for {url}")
+        return None
+
+    except Exception as e:
+        print(f"Error in safe_requests_get: {e}")
+        return None

--- a/tests/test_dos_limits.py
+++ b/tests/test_dos_limits.py
@@ -18,10 +18,11 @@ class TestHandlerDoS(unittest.TestCase):
             }
         }
 
-        handler(event)
+        result = handler(event)
 
-        # Verify that extract_substack_content was called with the CAPPED number
-        mock_extract.assert_called_with('https://example.com', MAX_POSTS_PER_NEWSLETTER)
+        # Verify that it returns an error
+        self.assertIn('error', result)
+        mock_extract.assert_not_called()
 
     @patch('handler.extract_substack_content')
     @patch('handler.analyze_research_intelligence')
@@ -38,10 +39,11 @@ class TestHandlerDoS(unittest.TestCase):
             }
         }
 
-        handler(event)
+        result = handler(event)
 
-        # Verify it processed only MAX_NEWSLETTERS
-        self.assertEqual(mock_extract.call_count, MAX_NEWSLETTERS)
+        # Verify that it returns an error
+        self.assertIn('error', result)
+        mock_extract.assert_not_called()
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_safe_requests.py
+++ b/tests/test_safe_requests.py
@@ -1,0 +1,88 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from security_utils import safe_requests_get
+import requests
+
+class TestSafeRequestsGet(unittest.TestCase):
+    @patch('requests.get')
+    def test_safe_url_no_redirect(self, mock_get):
+        # Setup mock for a safe URL
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {}
+        mock_response.history = []
+        mock_get.return_value = mock_response
+
+        # Call function
+        resp = safe_requests_get("http://example.com/safe")
+
+        # Verify
+        self.assertIsNotNone(resp)
+        self.assertEqual(resp.status_code, 200)
+
+    @patch('requests.get')
+    def test_unsafe_initial_url(self, mock_get):
+        # Should return None or raise exception before calling requests.get
+        # But wait, safe_requests_get might call is_safe_url first.
+
+        resp = safe_requests_get("http://127.0.0.1/unsafe")
+        self.assertIsNone(resp)
+        mock_get.assert_not_called()
+
+    @patch('requests.get')
+    def test_redirect_to_unsafe_url(self, mock_get):
+        # Setup redirect chain: safe -> unsafe
+
+        # First response: 302 Redirect to private IP
+        response1 = MagicMock()
+        response1.status_code = 302
+        response1.headers = {'Location': 'http://169.254.169.254/secret'}
+        response1.is_redirect = True
+
+        # We expect safe_requests_get to NOT follow this if it checks the location
+
+        # To simulate this with a loop in safe_requests_get, we return response1 first.
+        # If safe_requests_get blindly followed, it would call get again.
+
+        mock_get.side_effect = [response1]
+
+        # Call function
+        resp = safe_requests_get("http://example.com/redirect")
+
+        # It should detect the unsafe location and stop
+        self.assertIsNone(resp)
+        # Should verify it didn't call get on the unsafe url
+        # mock_get should have been called once with the safe url
+        mock_get.assert_called_once()
+        args, _ = mock_get.call_args
+        self.assertEqual(args[0], "http://example.com/redirect")
+
+    @patch('requests.get')
+    def test_safe_redirect(self, mock_get):
+        # Safe -> Safe
+
+        response1 = MagicMock()
+        response1.status_code = 302
+        response1.headers = {'Location': 'http://example.com/final'}
+        response1.is_redirect = True
+
+        response2 = MagicMock()
+        response2.status_code = 200
+        response2.headers = {}
+        response2.is_redirect = False
+
+        mock_get.side_effect = [response1, response2]
+
+        resp = safe_requests_get("http://example.com/start")
+
+        self.assertIsNotNone(resp)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(mock_get.call_count, 2)
+
+        # Verify calls
+        calls = mock_get.call_args_list
+        self.assertEqual(calls[0][0][0], "http://example.com/start")
+        self.assertEqual(calls[1][0][0], "http://example.com/final")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: SSRF via redirects was possible because `requests.get` followed redirects by default, bypassing the initial IP check. Also, DoS limits were inconsistently applied (truncation vs error), violating the security policy.
🎯 Impact: Attackers could access internal services (e.g., metadata service) by redirecting a valid URL to a private IP. Users were not informed when their requests were truncated.
🔧 Fix: Implemented `safe_requests_get` in `security_utils.py` to handle redirects manually and validate each hop. Updated `handler.py` to use `safe_requests_get` and enforce DoS limits via explicit errors.
✅ Verification: Added `tests/test_safe_requests.py` which verifies unsafe redirects are blocked. Updated `tests/test_dos_limits.py` to assert error returns. All tests pass.

---
*PR created automatically by Jules for task [17829518149710315811](https://jules.google.com/task/17829518149710315811) started by @thebearwithabite*